### PR TITLE
Remove deprecated arcfour256 and arcfour128 ciphers

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@
 
 system_sshd_sftp_path: /usr/lib/openssh/sftp-server
 system_sshd_service_name: ssh
-system_sshd_ciphers: aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128
+system_sshd_ciphers: aes128-ctr,aes192-ctr,aes256-ctr
 
 update_grub_cmd: update-grub
 


### PR DESCRIPTION
The `arcfour256` and `arcfour128` have been deprecated for a while now and with latest OpenSSH using them will stop the `sshd` from starting due to:

```
/etc/ssh/sshd_config line: 42: Bad SSH2 cipher spec 'aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128'
```